### PR TITLE
Fixed compilation issues with GLUT on linux

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -50,6 +50,9 @@ add_executable(plycmd plycmd.cc)
 if (GLEW_FOUND)
   target_link_libraries(plycmd GLEW::GLEW)
 endif ()
+if (GLUT_FOUND)
+  target_link_libraries(plycmd ${GLUT_LIBRARIES})
+endif ()
 target_link_libraries(plycmd gvr_static ${libs})
 
 install(TARGETS imgcmd plycmd DESTINATION bin)
@@ -68,15 +71,16 @@ if (OPENGL_FOUND AND GLUT_FOUND AND GLEW_FOUND)
   include_directories(${GLUT_INCLUDE_DIR})
   include_directories(${GLEW_INCLUDE_DIRS})
   add_definitions(-DINCLUDE_GL)
-  
+
   add_executable(plyv plyv.cc)
   target_link_libraries(plyv GLEW::GLEW)
+  target_link_libraries(plyv ${GLUT_LIBRARIES})
   target_link_libraries(plyv gvr_static ${libs})
-  
+
   if (WIN32)
     target_link_libraries(plyv gdi32 "-Wl,--subsystem,windows")
   endif ()
-  
+
   install(TARGETS plyv DESTINATION bin)
 endif ()
 


### PR DESCRIPTION
Hi

This fixes the missing glut library while linking plycmd, plyv on fedora f35.

[ 96%] Linking CXX executable plycmd
/usr/bin/ld: ../gvr/libgvr_static.a(glmisc.cc.o): in function `gvr::renderInfoText(char const*, long, long)':
glmisc.cc:(.text+0x146): undefined reference to `glutBitmap9By15'
/usr/bin/ld: glmisc.cc:(.text+0x15b): undefined reference to `glutBitmapWidth'
/usr/bin/ld: glmisc.cc:(.text+0x31c): undefined reference to `glutBitmap9By15'
/usr/bin/ld: glmisc.cc:(.text+0x333): undefined reference to `glutBitmapCharacter'
/usr/bin/ld: ../gvr/libgvr_static.a(glmisc.cc.o): in function `gvr::renderInfoLine(char const*, long)':
glmisc.cc:(.text+0x500): undefined reference to `glutBitmap9By15'
/usr/bin/ld: glmisc.cc:(.text+0x510): undefined reference to `glutBitmapCharacter'
collect2: error: ld returned 1 exit status
make[2]: *** [tools/CMakeFiles/plycmd.dir/build.make:111: tools/plycmd] Error 1
make[1]: *** [CMakeFiles/Makefile2:561: tools/CMakeFiles/plycmd.dir/all] Error 2
make: *** [Makefile:166: all] Error 2

The patch has been tested only on f35. Feel free to amend :)

Signed-off-by: Xavier Roumegue <xavier.roumegue@nxp.com>